### PR TITLE
fix minor error in quarto command to install extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ on [Steven Miller's R Markdown templates](https://github.com/svmiller/stevetempl
 ## Installing
 
 ```bash
-quarto install template mps9506/quarto-cv
+quarto install extension mps9506/quarto-cv
 ```
 
 This will install the template for use with existing Quarto projects or documents.


### PR DESCRIPTION
The `REAMDE.md` file has:
```bash
quarto install template mps9506/quarto-cv
```
which results in this confusing message
```bash
Could not install 'mps9506/quarto-cv'- try again with one of the following:
  quarto install tool tinytex
  quarto install tool chromium
```

but the command should be
```bash
quarto install extension mps9506/quarto-cv
```
and installation proceeds as expected.

