### PR TITLE
Optionally render bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ CJKmainfont: Noto Sans CJK JP
 
 The `CJKmainfont:` yaml key should point to a locally installed font.
 
+### Bullet Point Lists
+By default, lists are displayed without bullet points. To switch on, add the following to the header:
+
+```yaml
+bullets: true
+```
+
 ## Example
 
 Here is the source code for a minimal sample document: [template.qmd](template.qmd).

--- a/_extensions/quarto-cv/quarto-cv.tex
+++ b/_extensions/quarto-cv/quarto-cv.tex
@@ -96,6 +96,8 @@ $endfor$
 
 
 % Make lists without bullets
+$if(bullets)$
+$else$
 \renewenvironment{itemize}{
   \begin{list}{}{
     \setlength{\leftmargin}{1.5em}
@@ -103,7 +105,7 @@ $endfor$
 }{
   \end{list}
 }
-
+$endif$
 
 % Make parskips rather than indent with lists.
 \usepackage{parskip}


### PR DESCRIPTION
Hi, please feel free to reject if this isn't to your taste.

I wanted to be able to optionally render lists with bullet points, which are rendered without by default.

This PR adds a header option to toggle rendering of bullet points:

```yaml
bullets: true
```

The if statement in `_extensions/quarto-cv/quarto-cv.tex` is probably incorrect, I'm not familiar with the language but this does work functionally, even if ugly.